### PR TITLE
Added default for target setting

### DIFF
--- a/antispam.yaml
+++ b/antispam.yaml
@@ -1,1 +1,2 @@
 enabled: true
+target: false


### PR DESCRIPTION
This pull request adds the missing default value for the target setting in #13 

But I don't know a lot about GRAV if this default value is automatically applied if the plugin is updated.
Right know I'm not able to test this.